### PR TITLE
feat: add severity level to advisories

### DIFF
--- a/lib/elixir_security_advisories/dump.ex
+++ b/lib/elixir_security_advisories/dump.ex
@@ -16,7 +16,7 @@ defmodule ElixirSecurityAdvisories.Dump do
     |> Enum.map(&map_advisory_to_file/1)
   end
 
-  defp map_vulnerabilities_to_advisories({_, vulnerabilities = [%{"advisory" => advisory, "package" => package} | _]}) do
+  defp map_vulnerabilities_to_advisories({_, vulnerabilities = [%{"advisory" => advisory, "package" => package, "severity" => severity} | _]}) do
     %{
       id: advisory["ghsaId"],
       package: package["name"],
@@ -25,7 +25,8 @@ defmodule ElixirSecurityAdvisories.Dump do
       title: advisory["summary"],
       description: advisory["description"],
       first_patched_versions: Enum.map(vulnerabilities, & &1["firstPatchedVersion"]["identifier"]),
-      vulnerable_version_ranges: Enum.map(vulnerabilities, & &1["vulnerableVersionRange"])
+      vulnerable_version_ranges: Enum.map(vulnerabilities, & &1["vulnerableVersionRange"]),
+      severity: String.downcase(severity)
     }
   end
 

--- a/lib/elixir_security_advisories/repo.ex
+++ b/lib/elixir_security_advisories/repo.ex
@@ -32,6 +32,7 @@ defmodule ElixirSecurityAdvisories.Repo do
           summary
           publishedAt
         }
+        severity
       }
     }
   }


### PR DESCRIPTION
## 📖 Description and reason

Add severity level to advisories to prioritize vulnerabilities. 

## 🎉 Result

```diff
---
description: The `class` attribute was not protected against XSS attacks when using HEEx.
disclosure_date: 2022-04-12
first_patched_versions:
  - 3.0.4
id: GHSA-j3gg-r6gp-95q2
link: https://github.com/advisories/GHSA-j3gg-r6gp-95q2
package: phoenix_html
+ severity: moderate
title: XSS in HEEx class attributes
vulnerable_version_ranges:
  - < 3.0.4
```