### PR TITLE
Use “git” commands in CD workflow instead of external action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,19 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
       - uses: erlef/setup-beam@v1
         with:
           otp-version: 25.0
           elixir-version: 1.13
-
       - run: make dependencies
-
       - run: make build
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: EndBug/add-and-commit@v9
-        with:
-          message: Update advisories from GitHub Advisory Database
-          default_author: github_actions
+      - run: git config user.name "github-actions[bot]"
+      - run: git config user.email "github-actions[bot]@users.noreply.github.com"
+      - run: git add -A
+      - run: git diff-index --quiet HEAD || git commit -m "Update advisories from GitHub Advisory Database"
+      - run: git push origin HEAD


### PR DESCRIPTION
## 📖 Description and reason

Instead of using the [EndBug/add-and-commit](https://github.com/EndBug/add-and-commit) action, we can use a simple combination of `git` commands.

## 👷 Work done

#### Tasks

- [x] Replace `EndBug/add-and-commit` with 5 `git` commands

## 🦀 Dispatch

`#dispatch/devops`
