### PR TITLE
Upgrade to Elixir 1.14

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: 25.0
-          elixir-version: 1.13
+          elixir-version: 1.14
       - run: make dependencies
       - run: make build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: 25.0
-          elixir-version: 1.13
+          elixir-version: 1.14
 
       - run: make dependencies
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ElixirSecurityAdvisories.MixProject do
     [
       app: :elixir_security_advisories,
       version: "0.1.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
## 📖 Description and reason

Let’s use Elixir 1.14!

## 👷 Work done

#### Tasks

- [x] Bump version requirement in `mix.exs`
- [x] Bump version requirement in CI/CD workflows

## 🦀 Dispatch

`#dispatch/elixir`
